### PR TITLE
Centralize seeding.

### DIFF
--- a/complex/src/malice/args.py
+++ b/complex/src/malice/args.py
@@ -67,8 +67,8 @@ def parse_args():
                         default=10)
     parser.add_argument('--seed',
                         type=int,
-                        help='initial seed for PyGMO (not deterministic, but gets closer)',
-                        default=1337)
+                        help='random seed (still not deterministic if using multiple threads)',
+                        default=None)
     parser.add_argument('--tolerance',
                         type=float,
                         help='PyGMO tolerance for both ftol and xtol',

--- a/complex/src/malice/mcmc.py
+++ b/complex/src/malice/mcmc.py
@@ -4,10 +4,8 @@ import scipy.stats as stats
 from malice.optimizer import MaliceOptimizer
 
 
-def walk(optimizer, steps, confidence, min_global, max_global, seed,
+def walk(optimizer, steps, confidence, min_global, max_global,
          iterator=1, abort_threshold=100):
-
-    np.random.seed(seed=9*seed + 89*iterator)
 
     walker = MaliceOptimizer(larmor=optimizer.larmor,
                              gvs=optimizer.gvs,

--- a/complex/src/malice/output.py
+++ b/complex/src/malice/output.py
@@ -11,8 +11,7 @@ def make_output_dir(directory):
 
 
 def create_output_files(optimizer, confidence, gvs, residues, fname_prefix,
-                        output_dir, config, lam, pygmo_seed, performance,
-                        fit_points):
+                        output_dir, config, lam, performance, fit_points):
     # Generate a CSV with confidence intervals for all of the delta_w's and
     # trajectories if available
     alpha = 100.0*(1-confidence)/2
@@ -41,6 +40,6 @@ def create_output_files(optimizer, confidence, gvs, residues, fname_prefix,
     make_output_dir(image_dir)
 
     # Generate summary PDF
-    summary_pdf = CompLEx_Report(optimizer, config, performance, lam, pygmo_seed, image_dir)
+    summary_pdf = CompLEx_Report(optimizer, config, performance, lam, image_dir)
     summary_pdf_name = os.path.join(output_dir, fname_prefix + '_CompLEx_summary.pdf')
     summary_pdf.output(summary_pdf_name)

--- a/complex/src/malice/reporter.py
+++ b/complex/src/malice/reporter.py
@@ -15,6 +15,7 @@ import scipy.stats as stats
 from scipy.optimize import minimize
 
 from malice.resources import fonts
+from malice.seeds import get_base_seed
 
 
 def truncate_colormap(cmap, minval=0.0, maxval=1.0, n=256):
@@ -344,7 +345,7 @@ def set_font_dir():
      font_dir = pathlib.Path(fonts.__file__).parent.absolute()
      fpdf.FPDF_FONT_DIR = font_dir
 
-def CompLEx_Report(optimizer, config, performance, lam, seed, image_dir):
+def CompLEx_Report(optimizer, config, performance, lam, image_dir):
     pdf = CompLEx_PDF(orientation='portrait', unit='in', format='letter')
     pdf.set_margins(0.5,0.5,0.5)
     set_font_dir()
@@ -406,7 +407,7 @@ def CompLEx_Report(optimizer, config, performance, lam, seed, image_dir):
                        ('Population size', config.pop_size),
                        ('MCMC walks', config.mcmc_walks),
                        ('MCMC steps', config.mcmc_steps),
-                       ('Founder seed', seed),
+                       ('Founder seed', get_base_seed()),
                        ('PyGMO tolerance', format(config.tolerance, '.1g')),
                        ('Least squares max iterations', format(config.least_squares_max_iter,'.1g'))]
     pdf.set_font(fixed_width,'BI',12)

--- a/complex/src/malice/seeds.py
+++ b/complex/src/malice/seeds.py
@@ -1,0 +1,19 @@
+import random
+
+import numpy as np
+import pygmo as pg
+
+_base_seed = None
+
+def set_base_seed(seed):
+    if seed is None:
+        # Set seed randomly if not explicitly seeded
+        seed = random.randint(0, 999999)
+        
+    _base_seed = seed
+    np.random.seed(seed)
+    pg.set_global_rng_seed(seed)
+    random.seed(seed)
+
+def get_base_seed():
+    return _base_seed


### PR DESCRIPTION
- Set all global seeds (numpy, pygmo, vanilla) in one function.

- Remove all reseeding performed throughout computation.