### PR TITLE
Test simulated peak generation.

### DIFF
--- a/complex/src/test/test_optimizer.py
+++ b/complex/src/test/test_optimizer.py
@@ -151,6 +151,33 @@ class TestOptimizer(TestCase):
 
         assert_series_equal(actual_row, expected_row, check_less_precise=True, check_names=False)
 
+    def test_simulated_peak_generation(self):
+        optimizer = _test_object()
+        optimizer.ml_model = _prefit_model()
+        optimizer.lam = 0.
+        optimizer.mode = "simulated_peak_generation"
+        optimizer.cs_dist = "rayleigh"
+
+        optimizer.reference[["15N_ref", "1H_ref", "I_ref"]] += \
+            np.array([[0.1, 0.2, 0.3]]).T
+
+        actual_df = optimizer.fitness()
+        # TODO(auberon): Switch to less brittle test once fitness function refactored.
+        expected_df = pd.DataFrame({'15N': {0: 124.56700000000001, 1: 124.565, 2: 126.77600000000001, 3: 126.777, 4: 121.124, 5: 121.125},
+                                    '15N_ref': {0: 124.667, 1: 124.667, 2: 126.97600000000001, 3: 126.97600000000001, 4: 121.42399999999999, 5: 121.42399999999999},
+                                    '1H': {0: 7.763, 1: 7.763, 2: 8.349, 3: 8.349, 4: 8.202, 5: 8.201},
+                                    '1H_ref': {0: 7.8629999999999995, 1: 7.8629999999999995, 2: 8.549, 3: 8.549, 4: 8.502, 5: 8.502},
+                                    'I_ref': {0: 3248421.1, 1: 3248421.1, 2: 5053537.2, 3: 5053537.2, 4: 2062229.3, 5: 2062229.3},
+                                    'csfit': {0: 0.0, 1: 0.0005911449393205245, 2: 0.0, 3: 0.00043509098136506013, 4: 0.0, 5: 0.0011225874938422644},
+                                    'csp': {0: 0.10198039027185513, 1: 0.10205959043617586, 2: 0.2039607805437108, 3: 0.2039216516214007, 4: 0.3059411708155677, 5: 0.3068827789238098}, 'dw': {0: 40.79, 1: 40.79, 2: 30.02, 3: 30.02, 4: 77.49, 5: 77.49},
+                                    'ifit': {0: 3248421.1, 1: 3208792.432251481, 2: 5053537.2, 3: 4959741.54402069, 4: 2062229.3, 5: 2044766.7717852024},
+                                    'intensity': {0: 3248421.0, 1: 3191240.0, 2: 5053537.0, 3: 4964073.0, 4: 2062229.0, 5: 2136456.0},
+                                    'residue': {0: 6, 1: 6, 2: 7, 3: 7, 4: 9, 5: 9},
+                                    'titrant': {0: 0.0, 1: 7.9, 2: 0.0, 3: 7.9, 4: 0.0, 5: 7.9},
+                                    'visible': {0: 150.0, 1: 150.0, 2: 150.0, 3: 150.0, 4: 150.0, 5: 150.0}})
+
+        assert_frame_equal(actual_df, expected_df, check_like=True)
+    
     def test_observed_chemical_shift(self):
         optimizer = _test_object()
 


### PR DESCRIPTION
- Add test for simulated peak generation. To be made less brittle once
  fitness function is refactored.